### PR TITLE
Core object tensor support

### DIFF
--- a/magpy/core/function_product.py
+++ b/magpy/core/function_product.py
@@ -1,4 +1,5 @@
 from numbers import Number
+from copy import deepcopy
 import torch
 import magpy as mp
 
@@ -52,10 +53,10 @@ class FunctionProduct:
             return other * self
 
         out = FunctionProduct()
-        out.funcs = self.funcs.copy()
-        out.scale = self.scale
+        out.funcs = deepcopy(self.funcs)
+        out.scale = deepcopy(self.scale)
 
-        if isinstance(other, Number):
+        if isinstance(other, Number | torch.Tensor):
             out.scale *= other
         else:
             try:
@@ -85,7 +86,7 @@ class FunctionProduct:
         return f"{str(self.scale)}*{str(self.funcs)}"
 
     def __str__(self):
-        return (str(self.scale) + "*" if self.scale != 1 else "") \
+        return (str(self.scale) + "*" if isinstance(self.scale, torch.Tensor) or self.scale != 1 else "") \
             + '*'.join([f.__name__ + (f"^{str(n)}" if n > 1 else "") for f, n in self.funcs.items()])
 
     def __hash__(self):

--- a/magpy/core/hamiltonian_operator.py
+++ b/magpy/core/hamiltonian_operator.py
@@ -129,7 +129,7 @@ class HamiltonianOperator:
                 p_str = str(p)
                 scale_pos = p_str.find('*')
 
-                if p.scale != 1:
+                if isinstance(p.scale, torch.Tensor) or p.scale != 1:
                     out += p_str[:scale_pos] + '*'
 
                 out = HamiltonianOperator.__add_coeff_to_str(out, f)
@@ -226,10 +226,9 @@ class HamiltonianOperator:
 
             # Evaluate coefficient if it's a function.
             try:
-                coeff = coeff(t)
+                coeff = coeff(t).to(_DEVICE_CONTEXT.device)
             except TypeError:
                 pass
-            coeff = coeff.to(_DEVICE_CONTEXT.device)
 
             # Evaluate next term in data.
             next_term = 0

--- a/magpy/core/pauli_string.py
+++ b/magpy/core/pauli_string.py
@@ -138,7 +138,7 @@ class PauliString:
         for index, qubit in self.qubits.items():
             qubits[index - 1] = PauliString.matrices[qubit]
 
-        scale = self.scale.view(len(self.scale), 1, 1) if isinstance(self.scale, torch.Tensor) else self.scale
+        scale = self.scale.view(len(self.scale), 1, 1).to(_DEVICE_CONTEXT.device) if isinstance(self.scale, torch.Tensor) else self.scale
         return scale * mp.kron(*qubits).type(torch.complex128).to(_DEVICE_CONTEXT.device)
 
     def __mul_ps(self, other):

--- a/magpy/core/pauli_string.py
+++ b/magpy/core/pauli_string.py
@@ -138,7 +138,8 @@ class PauliString:
         for index, qubit in self.qubits.items():
             qubits[index - 1] = PauliString.matrices[qubit]
 
-        scale = self.scale.view(len(self.scale), 1, 1).to(_DEVICE_CONTEXT.device) if isinstance(self.scale, torch.Tensor) else self.scale
+        scale = self.scale.view(len(self.scale), 1, 1).to(_DEVICE_CONTEXT.device) \
+            if isinstance(self.scale, torch.Tensor) else self.scale
         return scale * mp.kron(*qubits).type(torch.complex128).to(_DEVICE_CONTEXT.device)
 
     def __mul_ps(self, other):


### PR DESCRIPTION
Add support for Tensor constant and function coefficients in the three core objects:
- FunctionProduct
- PauliString
- HamiltonianOperator

This allows for HOps like: `H = sin*X() + tensor([1,2])*Y()`, which represents the following combined:

`H = sin*X() + Y()`
`H = sin*X() + 2*Y()`

And similarly with the other two objects.

Closes #2 